### PR TITLE
Add project based on `serialization.zig` to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ a third party package.
 Feel free to start your own source code repository and take over the duties
 of maintaining any of this code! You can send PRs to this README to link to
 your project.
+
+## Adaptations
+
+- `serialization.zig`
+  - [SeanTheGleaming/zig-serialization](https://github.com/SeanTheGleaming/zig-serialization) provides the same API as `serialization.zig` updated to modern Zig and with additional features


### PR DESCRIPTION
Hey, I have made a project based upon `serialization.zig`, and I would like to add it to the README. This seems to be the first addition of a project into the README, so I started a bullet-point list of files and associated adaptations. If any maintainers would like to specify a different format for adding projects to the README, that would be great.

Lastly, a question about the licensing. This project started as just a port of the `serialization.zig` to modern Zig, but by now, most of the code has been rewritten from scratch outside of parts of some of the tests. I'm not sure where that puts me in terms of the MIT license on `std.serialization`. Does anyone with more experience know whether the zig MIT license applies to the code?